### PR TITLE
document runXXX for State, Reader, Except

### DIFF
--- a/Control/Monad/Classes/Except.hs
+++ b/Control/Monad/Classes/Except.hs
@@ -43,8 +43,10 @@ type MonadExcept e m = MonadExceptN (Find (EffExcept e) m) e m
 throw :: forall a e m . MonadExcept e m => e -> m a
 throw = throwN (proxy# :: Proxy# (Find (EffExcept e) m))
 
+-- | Run an 'MonadExcept' effect using 'Exc.ExceptT'.
 runExcept :: Exc.ExceptT e m a -> m (Either e a)
 runExcept = Exc.runExceptT
 
+-- | Run an 'MonadExcept' effect using 'Exc.MaybeT'.
 runMaybe :: Mb.MaybeT m a -> m (Maybe a)
 runMaybe = Mb.runMaybeT

--- a/Control/Monad/Classes/Reader.hs
+++ b/Control/Monad/Classes/Reader.hs
@@ -77,5 +77,8 @@ local :: forall a m r. MonadLocal r m
       -> m a
 local = localN (proxy# :: Proxy# (Find (EffLocal r) m))
 
+-- | Run a 'MonadReader' effect using 'R.ReaderT'.
+--
+-- This is a flipped 'R.runReaderT'.
 runReader :: r -> R.ReaderT r m a -> m a
 runReader = flip R.runReaderT

--- a/Control/Monad/Classes/State.hs
+++ b/Control/Monad/Classes/State.hs
@@ -62,17 +62,42 @@ modify f = state (\s -> ((), f s))
 modify' :: MonadState s m => (s -> s) -> m ()
 modify' f = state (\s -> let s' = f s in s' `seq` ((), s'))
 
+-- | Run a 'MonadState' effect using lazy 'SL.StateT'.
+--
+-- This is a flipped 'SL.runStateT'.
 runStateLazy   :: s -> SL.StateT s m a -> m (a, s)
 runStateLazy   =  flip SL.runStateT
+
+-- | Run a 'MonadState' effect using strict 'SS.StateT'.
+--
+-- This is a flipped 'SS.runStateT'.
 runStateStrict :: s -> SS.StateT s m a -> m (a, s)
 runStateStrict =  flip SS.runStateT
 
+-- | Run a 'MonadState' effect using lazy 'SL.StateT', discarding the final
+-- state.
+--
+-- This is a flipped 'SL.evalStateT'.
 evalStateLazy   :: Monad m => s -> SL.StateT s m a -> m a
 evalStateLazy   =  flip SL.evalStateT
+
+-- | Run a 'MonadState' effect using strict 'SS.StateT', discarding the final
+-- state.
+--
+-- This is a flipped 'SS.evalStateT'.
 evalStateStrict :: Monad m => s -> SS.StateT s m a -> m a
 evalStateStrict =  flip SS.evalStateT
 
+-- | Run a 'MonadState' effect using lazy 'SL.StateT', discarding the final
+-- value.
+--
+-- This is a flipped 'SL.execStateT'.
 execStateLazy   :: Monad m => s -> SL.StateT s m a -> m s
 execStateLazy   = flip SL.execStateT
+
+-- | Run a 'MonadState' effect using strict 'SS.StateT', discarding the final
+-- value.
+--
+-- This is a flipped 'SS.execStateT'.
 execStateStrict :: Monad m => s -> SS.StateT s m a -> m s
 execStateStrict = flip SS.execStateT


### PR DESCRIPTION
it does not document `MonadWriter`'s `run` functions, because i am not sure what to do about them. i am not sure, why you use a `StateT` instead of a `WriterT`, so i am reluncant to do that. i have not yet played around with `ZoomT`. i think the doc for `runZoom` deserve an example :).

after playing around it a bit more, i might write a few examples in the haddock of `Control.Monad.Classes`.