### PR TITLE
Update type index to match class instance head for ReadStateT's StT

### DIFF
--- a/Control/Monad/Classes/ReadState.hs
+++ b/Control/Monad/Classes/ReadState.hs
@@ -37,7 +37,7 @@ instance MonadBase b m => MonadBase b (ReadStateT x m) where
   liftBase = lift . liftBase
 
 instance MonadTransControl (ReadStateT x) where
-  type StT (ReadStateT s) a = StT IdentityT a
+  type StT (ReadStateT x) a = StT IdentityT a
   liftWith = defaultLiftWith ReadStateT (\(ReadStateT a) -> a)
   restoreT = defaultRestoreT ReadStateT
 

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,7 +1,7 @@
 # For more information, see: https://github.com/commercialhaskell/stack/blob/release/doc/yaml_configuration.md
 
 # Specifies the GHC version and set of packages available (e.g., lts-3.5, nightly-2015-09-21, ghc-7.10.2)
-resolver: lts-7.0
+resolver: lts-10.6
 
 # Local packages, usually specified by relative directory name
 packages:


### PR DESCRIPTION
Fixes the following error which presents itself in GHC 8.2

```
Control/Monad/Classes/ReadState.hs:40:8: error:
    • Type indexes must match class instance head
      Expected: StT (ReadStateT x) <tv>
        Actual: StT (ReadStateT s) a
      where the `<tv>' arguments are type variables,
      distinct from each other and from the instance variables
    • In the type instance declaration for ‘StT’
      In the instance declaration for ‘MonadTransControl (ReadStateT x)’
   |
40 |   type StT (ReadStateT s) a = StT IdentityT a
   |        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
```